### PR TITLE
Produce an owned result from parsing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ You can also use a build script to generate the parser (**TODO**: document).
 To parse a string with that grammar:
 ```rust
 let tokens = string.parse::<::gll::proc_macro::TokenStream>().unwrap();
-json_like::Value::parse_with(tokens, |result| {
-    let value = result.unwrap();
+json_like::Value::parse(tokens).unwrap().with(|value| {
     // ...
 });
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can also use a build script to generate the parser (**TODO**: document).
 To parse a string with that grammar:
 ```rust
 let tokens = string.parse::<::gll::proc_macro::TokenStream>().unwrap();
-json_like::Value::parse_with(tokens, |parser, result| {
+json_like::Value::parse_with(tokens, |result| {
     let value = result.unwrap();
     // ...
 });

--- a/macros/tests/basic.rs
+++ b/macros/tests/basic.rs
@@ -10,8 +10,7 @@ macro_rules! testcases {
         }
         #[test]
         fn $name() {
-            $name::$rule::parse_with($input, |result| {
-                let result = result.unwrap();
+            $name::$rule::parse($input).unwrap().with(|result| {
                 let forest = result.forest;
                 let result = format!("{:#?}", result);
                 // FIXME(eddyb) Remove this trailing-comma-ignoring hack

--- a/macros/tests/basic.rs
+++ b/macros/tests/basic.rs
@@ -10,8 +10,10 @@ macro_rules! testcases {
         }
         #[test]
         fn $name() {
-            $name::$rule::parse_with($input, |parser, result| {
-                let result = format!("{:#?}", result.unwrap());
+            $name::$rule::parse_with($input, |result| {
+                let result = result.unwrap();
+                let forest = result.forest;
+                let result = format!("{:#?}", result);
                 // FIXME(eddyb) Remove this trailing-comma-ignoring hack
                 // once rust-lang/rust#59076 reaches the stable channel.
                 let normalize = |s: &str| {
@@ -23,8 +25,9 @@ macro_rules! testcases {
                     $expected,
                     result
                 );
-                parser
-                    .gss
+                // FIXME(eddyb) find a way to do this, given that
+                // the GSS is no longer exposed in the public API.
+                /*gss
                     .dump_graphviz(
                         &mut File::create(concat!(
                             env!("CARGO_MANIFEST_DIR"),
@@ -32,9 +35,8 @@ macro_rules! testcases {
                             stringify!($name),
                             "-gss.dot"
                         )).unwrap(),
-                    ).unwrap();
-                parser
-                    .sppf
+                    ).unwrap();*/
+                forest
                     .dump_graphviz(
                         &mut File::create(concat!(
                             env!("CARGO_MANIFEST_DIR"),

--- a/macros/tests/json.rs
+++ b/macros/tests/json.rs
@@ -36,7 +36,7 @@ fn json_like_proc_macro() {
             test: [null, false, true, (format!("{:?}", Some(1 + 2)))]
         }
     };
-    json_like::Value::parse_with(tokens, |_, result| {
+    json_like::Value::parse_with(tokens, |result| {
         let result = format!("{:#?}", result.unwrap());
         // HACK(eddyb) clean up the result, as we have no span info.
         let result = result

--- a/macros/tests/json.rs
+++ b/macros/tests/json.rs
@@ -36,13 +36,13 @@ fn json_like_proc_macro() {
             test: [null, false, true, (format!("{:?}", Some(1 + 2)))]
         }
     };
-    json_like::Value::parse_with(tokens, |result| {
-        let result = format!("{:#?}", result.unwrap());
-        // HACK(eddyb) clean up the result, as we have no span info.
-        let result = result
-            .replace("Span..Span => ", "")
-            .replace("Span..Span", "?");
-        let expected = "\
+
+    let result = format!("{:#?}", json_like::Value::parse(tokens).unwrap());
+    // HACK(eddyb) clean up the result, as we have no span info.
+    let result = result
+        .replace("Span..Span => ", "")
+        .replace("Span..Span", "?");
+    let expected = "\
 Value::Object {
     fields: [
         Field {
@@ -110,16 +110,15 @@ Value::Object {
         }
     ]
 }";
-            // FIXME(eddyb) Remove this trailing-comma-ignoring hack
-            // once rust-lang/rust#59076 reaches the stable channel.
-            let normalize = |s: &str| {
-                s.replace(",\n", "\n")
-            };
-        assert!(
-            normalize(&result) == normalize(expected),
-            "mismatched output, expected:\n{}\n\nfound:\n{}",
-            expected,
-            result
-        );
-    })
+    // FIXME(eddyb) Remove this trailing-comma-ignoring hack
+    // once rust-lang/rust#59076 reaches the stable channel.
+    let normalize = |s: &str| {
+        s.replace(",\n", "\n")
+    };
+    assert!(
+        normalize(&result) == normalize(expected),
+        "mismatched output, expected:\n{}\n\nfound:\n{}",
+        expected,
+        result
+    );
 }

--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -563,7 +563,7 @@ fn ret() -> Thunk<impl ContFn> {
 }
 
 fn sppf_add(parse_node_kind: &ParseNodeKind, child: Src) -> Thunk<impl ContFn> {
-    thunk!(p.sppf.add(#parse_node_kind, c.fn_input.subtract_suffix(_range), #child);)
+    thunk!(p.sppf_add(#parse_node_kind, c.fn_input.subtract_suffix(_range), #child);)
 }
 
 trait ForEachThunk {

--- a/src/generate/templates/header.rs
+++ b/src/generate/templates/header.rs
@@ -28,10 +28,10 @@ impl<'a, 'i, I: ::gll::runtime::Input, T: ?Sized> Clone for Handle<'a, 'i, I, T>
 
 impl<'a, 'i, I: ::gll::runtime::Input, T: ?Sized> Handle<'a, 'i, I, T> {
     pub fn source(self) -> &'a I::Slice {
-        self.parser.input(self.node.range)
+        self.parser.sppf.input(self.node.range)
     }
     pub fn source_info(self) -> I::SourceInfo {
-        self.parser.source_info(self.node.range)
+        self.parser.sppf.source_info(self.node.range)
     }
 }
 

--- a/src/generate/templates/header.rs
+++ b/src/generate/templates/header.rs
@@ -3,6 +3,20 @@ pub type Any = dyn any::Any;
 #[derive(Debug)]
 pub struct Ambiguity<T>(T);
 
+pub struct OwnedHandle<I: ::gll::runtime::Input, T: ?Sized> {
+    forest_and_node: ::gll::runtime::OwnedParseForestAndNode<_P, I>,
+    _marker: PhantomData<T>,
+}
+
+impl<I: ::gll::runtime::Input, T: ?Sized> OwnedHandle<I, T> {
+    pub fn source_info(&self) -> I::SourceInfo {
+        self.forest_and_node.unpack_ref(|_, forest_and_node| {
+            let (ref forest, node) = *forest_and_node;
+            forest.source_info(node.range)
+        })
+    }
+}
+
 pub struct Handle<'a, 'i: 'a, I: 'a + ::gll::runtime::Input, T: ?Sized> {
     pub node: ParseNode<'i, _P>,
     pub forest: &'a ::gll::runtime::ParseForest<'i, _P, I>,

--- a/src/generate/templates/header.rs
+++ b/src/generate/templates/header.rs
@@ -1,12 +1,3 @@
-#[derive(Debug)]
-pub enum ParseError<T> {
-    TooShort(T),
-    NoParse,
-}
-
-pub type ParseResult<'a, 'i, I, T> =
-    Result<Handle<'a, 'i, I, T>, ParseError<Handle<'a, 'i, I, T>>>;
-
 pub type Any = dyn any::Any;
 
 #[derive(Debug)]

--- a/src/high.rs
+++ b/src/high.rs
@@ -1,0 +1,161 @@
+//! Utilities for emulating HKTs (over lifetimes) in Rust.
+
+use std::mem;
+use std::ops::{Deref, DerefMut};
+
+/// Type lambda application, with a lifetime.
+pub trait ApplyL<'a> {
+    type Out;
+}
+
+/// Type lambda taking a lifetime, i.e. `Lifetime -> Type`.
+pub trait LambdaL: for<'a> ApplyL<'a> {}
+
+impl<T: for<'a> ApplyL<'a>> LambdaL for T {}
+
+// HACK(eddyb) work around `macro_rules` not being `use`-able.
+pub use crate::__high_type_lambda as type_lambda;
+
+/// Define a new "type lambda" (over a lifetime).
+///
+/// For example, `type_lambda!(type<'a> X = Y<Z<'a>>;)` defines
+/// a `struct X {...}` that implements `ApplyL`, such that
+/// `for<'a> <X as ApplyL<'a>>::Out = Y<Z<'a>>` holds.
+#[macro_export]
+macro_rules! __high_type_lambda {
+    ($($vis:vis type<$lt:lifetime> $name:ident $(<$($T:ident $(: $bound:path)*),*>)* = $ty:ty;)+) => {
+        $($vis struct $name $(<$($T $(: $bound)*),*>)* {
+            _marker: ::std::marker::PhantomData<($($($T),*)*)>,
+        }
+        impl<$lt, $($($T $(: $bound)*),*)*> $crate::high::ApplyL<$lt>
+            for $name $(<$($T),*>)*
+        {
+            type Out = $ty;
+        })+
+    }
+}
+
+type_lambda! {
+    pub type<'a> PairL<A: LambdaL, B: LambdaL> =
+        (<A as ApplyL<'a>>::Out, <B as ApplyL<'a>>::Out);
+}
+
+// HACK(eddyb) work around projection limitations with a newtype
+// FIXME(#52812) replace with `&'a <T as ApplyL<'b>>::Out`
+pub struct RefApplyL<'a, 'b, T: LambdaL>(&'a <T as ApplyL<'b>>::Out);
+
+impl<'a, 'b, T: LambdaL> Deref for RefApplyL<'a, 'b, T> {
+    type Target = <T as ApplyL<'b>>::Out;
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+// HACK(eddyb) work around projection limitations with a newtype
+// FIXME(#52812) replace with `&'a mut <T as ApplyL<'b>>::Out`
+pub struct RefMutApplyL<'a, 'b, T: LambdaL>(&'a mut <T as ApplyL<'b>>::Out);
+
+impl<'a, 'b, T: LambdaL> Deref for RefMutApplyL<'a, 'b, T> {
+    type Target = <T as ApplyL<'b>>::Out;
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}
+
+impl<'a, 'b, T: LambdaL> DerefMut for RefMutApplyL<'a, 'b, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0
+    }
+}
+
+/// Proof token for erasable lifetimes (soundly replaceable with existentials).
+/// That is, the lifetime is not used in references that borrow outside
+/// data, but rather only self-contained (e.g. `indexing` or `owning_ref`).
+#[derive(Copy, Clone)]
+pub struct ErasableL<'a> {
+    _marker: ::std::marker::PhantomData<&'a mut &'a ()>,
+}
+
+impl<'a> ErasableL<'a> {
+    /// Trivial proof that `'static` is erasable (it's always valid).
+    pub const STATIC: ErasableL<'static> = ErasableL {
+        _marker: ::std::marker::PhantomData,
+    };
+
+    /// Enter an `indexing::scope`, where the closure also receives a proof that
+    /// the generative lifetime is erasable (it doesn't come from a borrow).
+    pub fn indexing_scope<A: ::indexing::container_traits::Trustworthy, R>(
+        a: A,
+        f: impl for<'id> FnOnce(ErasableL<'id>, ::indexing::Container<'id, A>) -> R,
+    ) -> R {
+        ::indexing::scope(a, |container| {
+            f(
+                ErasableL {
+                    _marker: ::std::marker::PhantomData,
+                },
+                container,
+            )
+        })
+    }
+}
+
+/// Existential over a lifetime, i.e. `exists 'a.T('a)`.
+pub struct ExistsL<T: LambdaL>(<T as ApplyL<'static>>::Out);
+
+impl<T: LambdaL> ExistsL<T> {
+    /// Erase the lifetime `'a` from the value's type and wrap it in `ExistsL`.
+    /// This requires a proof that `'a` is erasable at all (see `ErasableL`).
+    /// To access the value later, use `unpack`, `unpack_ref` or `unpack_mut`.
+    pub fn pack<'a>(_: ErasableL<'a>, value: <T as ApplyL<'a>>::Out) -> Self {
+        let erased = unsafe { mem::transmute_copy(&value) };
+        mem::forget(value);
+        ExistsL(erased)
+    }
+
+    /// Provide owned access to the value, with the original lifetime replaced
+    /// by a generative lifetime, so that the closure can't assume equality
+    /// to any other specific lifetime (thanks to lifetime parametricity).
+    pub fn unpack<R>(
+        self,
+        f: impl for<'a> FnOnce(ErasableL<'a>, <T as ApplyL<'a>>::Out) -> R,
+    ) -> R {
+        let skolem = unsafe { mem::transmute_copy(&self.0) };
+        mem::forget(self);
+        f(
+            ErasableL {
+                _marker: ::std::marker::PhantomData,
+            },
+            skolem,
+        )
+    }
+
+    /// Provide shared access to the value, with the original lifetime replaced
+    /// by a generative lifetime, so that the closure can't assume equality
+    /// to any other specific lifetime (thanks to lifetime parametricity).
+    pub fn unpack_ref<R>(
+        &self,
+        f: impl for<'a, 'b> FnOnce(ErasableL<'b>, RefApplyL<'a, 'b, T>) -> R,
+    ) -> R {
+        f(
+            ErasableL {
+                _marker: ::std::marker::PhantomData,
+            },
+            RefApplyL(unsafe { &*(&self.0 as *const _ as *const _) }),
+        )
+    }
+
+    /// Provide mutable access to the value, with the original lifetime replaced
+    /// by a generative lifetime, so that the closure can't assume equality
+    /// to any other specific lifetime (thanks to lifetime parametricity).
+    pub fn unpack_mut<R>(
+        &mut self,
+        f: impl for<'a, 'b> FnOnce(ErasableL<'b>, RefMutApplyL<'a, 'b, T>) -> R,
+    ) -> R {
+        f(
+            ErasableL {
+                _marker: ::std::marker::PhantomData,
+            },
+            RefMutApplyL(unsafe { &mut *(&mut self.0 as *mut _ as *mut _) }),
+        )
+    }
+}

--- a/src/indexing_str.rs
+++ b/src/indexing_str.rs
@@ -1,0 +1,46 @@
+//! String slice support for the `indexing` crate.
+// FIXME(eddyb) ensure `indexing::Range` can't break `str`'s UTF-8 requirement
+
+use indexing::container_traits::{Contiguous, Trustworthy};
+use indexing::{Container, Range};
+use std::ops::Deref;
+
+pub struct Str(str);
+
+impl<'a> From<&'a str> for &'a Str {
+    fn from(s: &'a str) -> Self {
+        unsafe { &*(s as *const str as *const Str) }
+    }
+}
+
+impl Deref for Str {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+unsafe impl Trustworthy for Str {
+    type Item = u8;
+    fn base_len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+unsafe impl Contiguous for Str {
+    fn begin(&self) -> *const Self::Item {
+        self.0.as_ptr()
+    }
+    fn end(&self) -> *const Self::Item {
+        unsafe { self.begin().offset(self.0.len() as isize) }
+    }
+    fn as_slice(&self) -> &[Self::Item] {
+        self.0.as_bytes()
+    }
+}
+
+impl Str {
+    pub fn slice<'a, 'b, 'i>(input: &'b Container<'i, &'a Self>, range: Range<'i>) -> &'b Self {
+        unsafe { &*(&input[range] as *const [u8] as *const Str) }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,9 @@ extern crate ordermap;
 extern crate proc_macro2;
 extern crate proc_quote;
 
-// NOTE only this module can and does contain unsafe code.
+// NOTE only these two modules can and do contain unsafe code.
+#[allow(unsafe_code)]
+mod high;
 #[allow(unsafe_code)]
 mod indexing_str;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,28 @@
+#![deny(unsafe_code)]
+
 extern crate indexing;
 extern crate ordermap;
 extern crate proc_macro2;
 extern crate proc_quote;
 
+// NOTE only this module can and does contain unsafe code.
+#[allow(unsafe_code)]
+mod indexing_str;
+
+#[forbid(unsafe_code)]
 pub mod generate;
+#[forbid(unsafe_code)]
 pub mod grammar;
+#[forbid(unsafe_code)]
 pub mod proc_macro;
+#[forbid(unsafe_code)]
 pub mod runtime;
+#[forbid(unsafe_code)]
 pub mod scannerless;
 
 // HACK(eddyb) needed for bootstrapping `parse_grammar`.
 mod gll {
     pub(crate) use runtime;
 }
+#[forbid(unsafe_code)]
 mod parse_grammar;

--- a/src/parse_grammar.rs
+++ b/src/parse_grammar.rs
@@ -10,15 +10,16 @@ use std::str::FromStr;
 impl<Pat: From<SPat>> FromStr for ::grammar::Grammar<Pat> {
     type Err = ::runtime::ParseError<::runtime::LineColumnRange>;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        Grammar::parse_with(src, |g| {
-            let g = g.map_err(|err| err.map_partial(|handle| handle.source_info()))?;
-            let mut grammar = ::grammar::Grammar::new();
-            for rule_def in g.one().unwrap().rules {
-                let rule_def = rule_def.unwrap().one().unwrap();
-                grammar.define(rule_def.name.source(), rule_def.rule.one().unwrap().lower());
-            }
-            Ok(grammar)
-        })
+        let mut grammar = ::grammar::Grammar::new();
+        Grammar::parse(src)
+            .map_err(|err| err.map_partial(|handle| handle.source_info()))?
+            .with(|g| {
+                for rule_def in g.one().unwrap().rules {
+                    let rule_def = rule_def.unwrap().one().unwrap();
+                    grammar.define(rule_def.name.source(), rule_def.rule.one().unwrap().lower());
+                }
+            });
+        Ok(grammar)
     }
 }
 

--- a/src/parse_grammar.rs
+++ b/src/parse_grammar.rs
@@ -8,21 +8,16 @@ use std::ops::Bound;
 use std::str::FromStr;
 
 impl<Pat: From<SPat>> FromStr for ::grammar::Grammar<Pat> {
-    type Err = ::runtime::LineColumn;
+    type Err = ::runtime::ParseError<::runtime::LineColumnRange>;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         Grammar::parse_with(src, |g| {
-            g.map_err(|err| match err {
-                ParseError::TooShort(handle) => handle.source_info().end,
-                ParseError::NoParse => ::runtime::LineColumn::default(),
-            })
-            .map(|g| {
-                let mut grammar = ::grammar::Grammar::new();
-                for rule_def in g.one().unwrap().rules {
-                    let rule_def = rule_def.unwrap().one().unwrap();
-                    grammar.define(rule_def.name.source(), rule_def.rule.one().unwrap().lower());
-                }
-                grammar
-            })
+            let g = g.map_err(|err| err.map_partial(|handle| handle.source_info()))?;
+            let mut grammar = ::grammar::Grammar::new();
+            for rule_def in g.one().unwrap().rules {
+                let rule_def = rule_def.unwrap().one().unwrap();
+                grammar.define(rule_def.name.source(), rule_def.rule.one().unwrap().lower());
+            }
+            Ok(grammar)
         })
     }
 }

--- a/src/parse_grammar.rs
+++ b/src/parse_grammar.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 impl<Pat: From<SPat>> FromStr for ::grammar::Grammar<Pat> {
     type Err = ::runtime::LineColumn;
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        Grammar::parse_with(src, |_, g| {
+        Grammar::parse_with(src, |g| {
             g.map_err(|err| match err {
                 ParseError::TooShort(handle) => handle.source_info().end,
                 ParseError::NoParse => ::runtime::LineColumn::default(),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -249,7 +249,7 @@ impl InputMatch<RangeInclusive<char>> for str {
 
 pub struct Parser<'i, P: ParseNodeKind, C: CodeLabel, I: Input> {
     pub threads: Threads<'i, C>,
-    pub gss: GraphStack<'i, C>,
+    gss: GraphStack<'i, C>,
     pub memoizer: Memoizer<'i, C>,
     pub sppf: ParseForest<'i, P, I>,
 }
@@ -429,7 +429,10 @@ pub struct GraphStack<'i, C: CodeLabel> {
 }
 
 impl<'i, C: CodeLabel> GraphStack<'i, C> {
-    pub fn dump_graphviz(&self, out: &mut Write) -> io::Result<()> {
+    // FIXME(eddyb) figure out what to do here, now that
+    // the GSS is no longer exposed in the public API.
+    #[allow(unused)]
+    fn dump_graphviz(&self, out: &mut Write) -> io::Result<()> {
         writeln!(out, "digraph gss {{")?;
         writeln!(out, "    graph [rankdir=RL]")?;
         for (call, returns) in &self.returns {


### PR DESCRIPTION
This is accomplished by adding an abstraction tool of the form `exists 'a.Foo<'a>`, where the `'a` is used for the [`indexing`](https://docs.rs/indexing) generative lifetime.