### PR TITLE
Copy license files from Rust.

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -192,7 +192,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,3 @@
-Copyright (c) 2017-2018 GLL Developers
-
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
 documentation files (the "Software"), to deal in the


### PR DESCRIPTION
This removes an unnecessary `Copyright ...` header from `LICENSE-MIT`.
Also, what should we do about the `authors` field in `Cargo.toml`?