### PR TITLE
Don't use "state" for `Rule::Or` parse nodes, and store them separately in the ParseForest.

### DIFF
--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -786,10 +786,12 @@ impl<Pat: Ord + Hash + RustInputPat> RuleGenerateMethods<Pat> for Rule<Pat> {
                 (thunk!(assert_eq!(_range.start(), c.fn_input.start());)
                     + parallel(ThunkIter(cases.iter().map(|rule| {
                         let parse_node_kind = rule.parse_node_kind(rules);
-                        push_state(quote!(#parse_node_kind.to_usize()))
-                            + rule.generate_parse(Some((rule, rules)))
-                    })))
-                    + pop_state(|state| sppf_add(&rc_self.parse_node_kind(rules), state)))
+                        rule.generate_parse(Some((rule, rules)))
+                            + sppf_add(
+                                &rc_self.parse_node_kind(rules),
+                                quote!(#parse_node_kind.to_usize()),
+                            )
+                    }))))
                 .apply(cont)
             }
             (Rule::Opt(rule), _) => {


### PR DESCRIPTION
Most of this is pretty straight-forward, although I went a bit far on the last commit.
I wish I could get farther, but all of these relative ranges are making it hard to reason about what's possible (I should've known the premature optimizations would eventually come back to haunt me...)