### PR TITLE
Parse grammars with `proc_macro` tokens and remove "negative lookahead".

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ doctest = false
 test = false
 
 [patch.'crates-io']
-grammer = { git = "https://github.com/lykenware/grammer", rev = "e108acbe83271761538bf5b2ff2daeaaafa5919c" }
+grammer = { git = "https://github.com/lykenware/grammer", rev = "ed4fc4f9be9aa2c1a6c3245ba4e91684ddff5f2f" }
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -9,6 +9,8 @@ extern crate proc_quote;
 mod generate;
 #[path = "src/parse_node.rs"]
 mod parse_node;
+#[path = "src/proc_macro.rs"]
+pub mod proc_macro;
 #[path = "src/scannerless.rs"]
 pub mod scannerless;
 
@@ -16,14 +18,13 @@ use std::env;
 use std::fs;
 use std::path::PathBuf;
 
-// FIXME(eddyb) use `scannerless::Grammar` when that wrapper hack is fixed.
-type Grammar = grammer::Grammar<scannerless::Pat<&'static str>>;
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let grammar: Grammar = grammer::grammar_grammar();
+    let mut grammar = proc_macro::builtin();
+    grammar.extend(grammer::grammar_grammar());
 
     fs::write(
         &out_dir.join("parse_grammar.rs"),

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,28 +7,16 @@ use proc_quote::ToTokens as _;
 
 #[proc_macro]
 pub fn scannerless_parser(input: TokenStream) -> TokenStream {
-    // FIXME(eddyb) parse the `proc_macro` tokens instead of strings.
-    gll::generate::rust::generate(
-        &input
-            .to_string()
-            .parse::<gll::scannerless::Grammar>()
-            .unwrap(),
-    )
-    .into_token_stream()
-    .into()
+    let grammar: gll::scannerless::Grammar = gll::parse_grammar(input.into()).unwrap();
+    gll::generate::rust::generate(&grammar)
+        .into_token_stream()
+        .into()
 }
 
 #[proc_macro]
 pub fn proc_macro_parser(input: TokenStream) -> TokenStream {
-    // FIXME(eddyb) parse the `proc_macro` tokens instead of strings.
     let mut grammar = gll::proc_macro::builtin();
-    grammar.extend(
-        input
-            .to_string()
-            .parse::<gll::proc_macro::Grammar>()
-            .unwrap()
-            .0,
-    );
+    grammar.extend(gll::parse_grammar(input.into()).unwrap());
     gll::generate::rust::generate(&grammar)
         .into_token_stream()
         .into()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,5 +18,12 @@ pub mod runtime;
 #[forbid(unsafe_code)]
 pub mod scannerless;
 
+// HACK(eddyb) this contains impls for types in `proc_macro`, which depend on
+// `runtime`. Those parts of `runtime` should be moved to `grammer::input`.
+#[forbid(unsafe_code)]
+mod proc_macro_runtime;
+
 #[forbid(unsafe_code)]
 mod parse_grammar;
+
+pub use parse_grammar::parse_grammar;

--- a/src/parse_grammar.rs
+++ b/src/parse_grammar.rs
@@ -67,9 +67,6 @@ impl Primary<'_, '_, TokenStream> {
     fn lower<Pat: From<SPat>>(self) -> grammer::RuleWithNamedFields<Pat> {
         match self {
             Primary::Eat(pat) => grammer::eat(pat.one().unwrap().lower()),
-            Primary::NegativeLookahead { pat } => {
-                grammer::negative_lookahead(pat.one().unwrap().lower())
-            }
             Primary::Call(name) => {
                 let name = match name.source() {
                     [FlatToken::Ident(ident)] => ident.to_string(),

--- a/src/proc_macro_runtime.rs
+++ b/src/proc_macro_runtime.rs
@@ -1,0 +1,83 @@
+use crate::proc_macro::{flatten, FlatToken, FlatTokenPat, Span, TokenStream};
+use crate::runtime::{Input, InputMatch, Range};
+use indexing::{proof::Provable, Container, Index, Unknown};
+use std::ops;
+
+impl Input for TokenStream {
+    type Container = Vec<FlatToken>;
+    type Slice = [FlatToken];
+    type SourceInfo = ops::Range<Span>;
+    type SourceInfoPoint = Span;
+    fn to_container(self) -> Self::Container {
+        let mut out = vec![];
+        flatten(self, &mut out);
+        out
+    }
+    fn slice<'b, 'i>(
+        input: &'b Container<'i, Self::Container>,
+        range: Range<'i>,
+    ) -> &'b Self::Slice {
+        &input[range.0]
+    }
+    fn source_info<'i>(
+        input: &Container<'i, Self::Container>,
+        range: Range<'i>,
+    ) -> Self::SourceInfo {
+        // FIXME(eddyb) should be joining up spans, but the API
+        // for that is still "semver-exempt" in `proc-macro2`.
+        let last = range
+            .nonempty()
+            .map(|r| r.last().no_proof())
+            .unwrap_or(range.past_the_end());
+        Self::source_info_point(input, range.first())..Self::source_info_point(input, last)
+    }
+    fn source_info_point<'i>(
+        input: &Container<'i, Self::Container>,
+        index: Index<'i, Unknown>,
+    ) -> Self::SourceInfoPoint {
+        // Try to get as much information as possible.
+        let (before, after) = input.split_at(index);
+        let before = &input[before];
+        let after = &input[after];
+        if let Some(first) = after.first() {
+            first.span()
+        } else if let Some(last) = before.last() {
+            // Not correct but we're at the end of the input anyway.
+            last.span()
+        } else {
+            // HACK(eddyb) last resort, make a span up
+            // (a better option should exist)
+            Span::call_site()
+        }
+    }
+}
+
+impl InputMatch<&'static [FlatTokenPat<&'static str>]> for [FlatToken] {
+    fn match_left(&self, &pat: &&[FlatTokenPat<&str>]) -> Option<usize> {
+        if self
+            .iter()
+            .zip(pat)
+            .take_while(|(t, p)| t.matches_pat(p))
+            .count()
+            == pat.len()
+        {
+            Some(pat.len())
+        } else {
+            None
+        }
+    }
+    fn match_right(&self, &pat: &&[FlatTokenPat<&str>]) -> Option<usize> {
+        if self
+            .iter()
+            .zip(pat)
+            .rev()
+            .take_while(|(t, p)| t.matches_pat(p))
+            .count()
+            == pat.len()
+        {
+            Some(pat.len())
+        } else {
+            None
+        }
+    }
+}

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -367,13 +367,6 @@ impl<'i, C: CodeStep<I>, I: Input> Parser<'i, C, I> {
         }
     }
 
-    pub fn input_lookahead_left<Pat>(&mut self, range: Range<'i>, pat: &'static Pat) -> bool
-    where
-        I::Slice: InputMatch<Pat>,
-    {
-        self.forest.input(range).match_left(pat).is_some()
-    }
-
     pub fn input_consume_right<Pat>(&self, range: Range<'i>, pat: &'static Pat) -> Option<Range<'i>>
     where
         I::Slice: InputMatch<Pat>,
@@ -383,13 +376,6 @@ impl<'i, C: CodeStep<I>, I: Input> Parser<'i, C, I> {
             .input(range)
             .match_right(pat)
             .map(|n| Range(range.split_at(range.len() - n).0))
-    }
-
-    pub fn input_lookbehind_right<Pat>(&self, range: Range<'i>, pat: &'static Pat) -> bool
-    where
-        I::Slice: InputMatch<Pat>,
-    {
-        self.forest.input(range).match_right(pat).is_some()
     }
 
     pub fn forest_add_choice(

--- a/src/scannerless.rs
+++ b/src/scannerless.rs
@@ -2,26 +2,7 @@ use grammer::{self, MatchesEmpty, MaybeKnown};
 use std::char;
 use std::ops::{self, Bound, RangeBounds};
 
-// HACK(eddyb) we want e.g. `.parse::<scannerless::Grammar>()` to keep working,
-// but `Grammar` comes from the `grammer` crate now - so we wrap it in order to
-// implement `FromStr` on the wrapper and use `Deref` to make it more seamless.
-// Also, it's here, and not in `parse_grammar`, so it exists during bootstrap.
-pub struct WrapperHack<T>(pub T);
-
-impl<T> std::ops::Deref for WrapperHack<T> {
-    type Target = T;
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<T> std::ops::DerefMut for WrapperHack<T> {
-    fn deref_mut(&mut self) -> &mut T {
-        &mut self.0
-    }
-}
-
-pub type Grammar<S = String> = WrapperHack<grammer::Grammar<Pat<S>>>;
+pub type Grammar<S = String> = grammer::Grammar<Pat<S>>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Pat<S = String, C = char> {


### PR DESCRIPTION
Fixes #110 and closes #14 (without providing a replacement).