### PR TITLE
Introduce a less fragile Parser API.

### DIFF
--- a/macros/tests/basic.rs
+++ b/macros/tests/basic.rs
@@ -176,4 +176,11 @@ testcases![
     A("abab") => "1:1-1:5",
     A("aba") => "1:1-1:4",
     A("b") => r#"1:1: error: expected ["a"]"#;
+
+    nested_or {
+        A = x:"x" { a:"a" | b:"b" };
+    }:
+    // FIXME(eddyb) figure out why the output is not `... => A {...}`.
+    A("xa") => "\
+1:1-1:3 => ";
 ];

--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -747,7 +747,7 @@ fn reify_as(label: Rc<CodeLabel>) -> Thunk<impl ContFn> {
 }
 
 fn forest_add_choice(parse_node_kind: &ParseNodeKind, choice: ParseNodeKind) -> Thunk<impl ContFn> {
-    thunk!(p.forest_add_choice(#parse_node_kind, p.fn_input.subtract_suffix(p.range), #choice);)
+    thunk!(p.forest_add_choice(#parse_node_kind, #choice);)
 }
 
 fn concat_and_forest_add(
@@ -766,7 +766,6 @@ fn concat_and_forest_add(
         + pop_saved(move |saved| {
             thunk!(p.forest_add_split(
                 #parse_node_kind,
-                p.fn_input.subtract_suffix(p.range),
                 #saved.range.len(),
             );)
         })

--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -471,7 +471,7 @@ impl Continuation<'_> {
         if let Code::Label(ref label) = self.code {
             self.code = Code::Inline(quote!(
                 c.code = #label;
-                p.threads.spawn(c, _range);
+                p.spawn(c, _range);
             ));
         }
 

--- a/src/generate/templates/imports.rs
+++ b/src/generate/templates/imports.rs
@@ -1,6 +1,5 @@
 use gll::runtime::{
-    nd::Arrow, traverse, Call, CodeLabel, Continuation, ParseNode, ParseNodeKind, ParseNodeShape,
-    Range,
+    nd::Arrow, traverse, CodeLabel, ParseNode, ParseNodeKind, ParseNodeShape, Range,
 };
 use std::any;
 use std::fmt;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -567,9 +567,16 @@ impl<'i, C: CodeLabel> Threads<'i, C> {
 struct Continuation<'i, C: CodeLabel> {
     code: C,
     saved: Option<ParseNode<'i, C::ParseNodeKind>>,
+    // FIXME(eddyb) for GC purposes, this would also need to be a `ParseNode`,
+    // except that's not always the case? But `ParseNode | Range` seems likely
+    // to be a deoptimization, especially if `ParseNode` stops containing a
+    // `Range` (e.g. if it's an index in a node array).
     result: Range<'i>,
 }
 
+// TODO(eddyb) figure out if `Call<Continuation<C>>` can be optimized,
+// based on the fact that `result.end == range.start` should always hold.
+// (Also, `range.end` is constant across a whole parse)
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 struct Call<'i, C> {
     callee: C,


### PR DESCRIPTION
*Based on #113, do not merge yet.*

Instead of the generated code poking at `runtime`'s data structures, it now relies on methods of `Parser`, which should be less easy to misuse.
This also removed `fn_input`, which was hackily used as a microoptimization, and broke after #107.