### PR TITLE
runtime: reset the result to the start of `B` in `A B`.

### DIFF
--- a/macros/tests/basic.rs
+++ b/macros/tests/basic.rs
@@ -180,7 +180,9 @@ testcases![
     nested_or {
         A = x:"x" { a:"a" | b:"b" };
     }:
-    // FIXME(eddyb) figure out why the output is not `... => A {...}`.
     A("xa") => "\
-1:1-1:3 => ";
+1:1-1:3 => A {
+    x: 1:1-1:2,
+    a: 1:2-1:3,
+}";
 ];

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -87,6 +87,14 @@ where
         self.remaining
     }
 
+    /// Get the current result range, and leave behind an empty range
+    /// (at the end of the current result / start of the remaining input).
+    pub fn take_result(&mut self) -> Range<'i> {
+        let result = self.result;
+        self.result = Range(result.frontiers().1);
+        result
+    }
+
     pub fn with_result_and_remaining<'a>(
         &'a mut self,
         result: Range<'i>,
@@ -174,6 +182,7 @@ where
 
     // FIXME(eddyb) safeguard this against misuse.
     pub fn forest_add_split(&mut self, kind: P, left: ParseNode<'i, P>) {
+        self.result = Range(left.range.join(self.result.0).unwrap());
         self.state
             .forest
             .possible_splits

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -131,7 +131,7 @@ where
     pub fn save(&mut self, kind: P) {
         let old_saved = self.saved.replace(ParseNode {
             kind,
-            range: self.parser.result(),
+            range: self.parser.take_result(),
         });
         assert_eq!(old_saved, None);
     }


### PR DESCRIPTION
@CAD97 reduced this in the `wg-grammar` repo, and it turns out the test I added in #114 was already exhibiting the issue!

The problem was that in `A B`, while parsing `B` we kept increasing the `result` range, so it contained `A` too, and when `B` was e.g. `C | D`, you'd end up with `C` (or `D`) nodes with the `A C` (or `A D`) range, which is the wrong one (and caused panics when using the `one_*` APIs).

I fixed it by resetting the `result` range to an empty range at the end of `A` / start of `B`, when saving `A` for later, and combining the range for `A` with the one for `B` when adding the parse node for `A B`.