### PR TITLE
Improve printing of expected patterns in parse errors.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ doctest = false
 test = false
 
 [patch.'crates-io']
-grammer = { git = "https://github.com/lykenware/grammer", rev = "e86adccdb75198f2e4e3c8a1bf23c4739dd27060" }
+grammer = { git = "https://github.com/lykenware/grammer", rev = "b0246724b67f50046d179e962c897eafe4cd0f26" }
 
 [workspace]
 members = [

--- a/macros/tests/basic.rs
+++ b/macros/tests/basic.rs
@@ -44,13 +44,9 @@ macro_rules! testcases {
                     format!("{:?}: error: expected {:?}", at, expected)
                 }
             };
-            // FIXME(eddyb) Remove this trailing-comma-ignoring hack
-            // once rust-lang/rust#59076 reaches the stable channel.
-            let normalize = |s: &str| {
-                s.replace(",\n", "\n")
-            };
+
             assert!(
-                normalize(&result) == normalize($expected),
+                result == $expected,
                 "mismatched output, expected:\n{}\n\nfound:\n{}",
                 $expected,
                 result
@@ -114,14 +110,14 @@ testcases![
     a: 1:1-1:2,
     s: 1:2-1:3 => S {
         s: 1:3-1:3 => S,
-        b: 1:2-1:3
-    }
+        b: 1:2-1:3,
+    },
 } | S {
     s: 1:2-1:4 => S {
         a: 1:2-1:3,
-        s: 1:3-1:3 => S
+        s: 1:3-1:3 => S,
     },
-    b: 1:1-1:2
+    b: 1:1-1:2,
 }";
 
     gll13_g1 {
@@ -151,9 +147,9 @@ testcases![
 1:1-1:4 => A::Y {
     a: 1:1-1:2,
     x: 1:2-1:3 => A::Z(
-        1:2-1:3
+        1:2-1:3,
     ),
-    c: 1:3-1:4
+    c: 1:3-1:4,
 }";
 
     gll15_g0_nested {
@@ -165,9 +161,9 @@ testcases![
 1:1-1:4 => A::X {
     a: 1:1-1:2,
     x: 1:2-1:3 => A::Z(
-        1:2-1:3
+        1:2-1:3,
     ),
-    b: 1:3-1:4
+    b: 1:3-1:4,
 }";
 
     repeat_many_trailing {

--- a/macros/tests/json.rs
+++ b/macros/tests/json.rs
@@ -34,11 +34,8 @@ fn json_like_testcase(input: &str, expected: &str) {
         .replace("?..? => ", "")
         .replace("?..?", "?");
 
-    // FIXME(eddyb) Remove this trailing-comma-ignoring hack
-    // once rust-lang/rust#59076 reaches the stable channel.
-    let normalize = |s: &str| s.replace(",\n", "\n");
     assert!(
-        normalize(&result) == normalize(expected),
+        result == expected,
         "mismatched output, expected:\n{}\n\nfound:\n{}",
         expected,
         result
@@ -71,14 +68,14 @@ Value::Object {
         Field {
             name: ?,
             value: Value::Literal(
-                ?
-            )
+                ?,
+            ),
         },
         Field {
             name: ?,
             value: Value::Literal(
-                ?
-            )
+                ?,
+            ),
         },
         Field {
             name: ?,
@@ -87,51 +84,51 @@ Value::Object {
                     Field {
                         name: ?,
                         value: Value::Literal(
-                            ?
-                        )
+                            ?,
+                        ),
                     },
                     Field {
                         name: ?,
                         value: Value::Literal(
-                            ?
-                        )
-                    }
-                ]
-            }
+                            ?,
+                        ),
+                    },
+                ],
+            },
         },
         Field {
             name: ?,
             value: Value::Array {
                 elems: [
                     Value::Literal(
-                        ?
+                        ?,
                     ),
                     Value::Literal(
-                        ?
-                    )
-                ]
-            }
+                        ?,
+                    ),
+                ],
+            },
         },
         Field {
             name: ?,
             value: Value::Array {
                 elems: [
                     Value::Null(
-                        ?
+                        ?,
                     ),
                     Value::False(
-                        ?
+                        ?,
                     ),
                     Value::True(
-                        ?
+                        ?,
                     ),
                     Value::InterpolateRust(
-                        ?
-                    )
-                ]
-            }
-        }
-    ]
+                        ?,
+                    ),
+                ],
+            },
+        },
+    ],
 }";
 
     json_like_testcase(input, expected);

--- a/macros/tests/json.rs
+++ b/macros/tests/json.rs
@@ -143,8 +143,7 @@ fn json_like_error() {
         stray_identifier
     };
 
-    let expected =
-r#"?: error: expected [[Ident(Some("null"))], [Ident(Some("false"))], [Ident(Some("true"))], [Delim('[')], [Delim('{')], [Delim('(')], [Literal]]"#;
+    let expected = r#"?: error: expected ["null", "false", "true", "[", "{", "(", LITERAL]"#;
 
     json_like_testcase(input, expected);
 }

--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -6,19 +6,19 @@ use grammer::{proc_macro, scannerless};
 
 use indexmap::{IndexMap, IndexSet};
 use std::borrow::Cow;
-use std::fmt::Write as FmtWrite;
+use std::fmt::{self, Write as _};
 use std::hash::Hash;
 use std::ops::Add;
 use std::rc::Rc;
 use std::{iter, mem};
 
-pub trait RustInputPat: Eq + Hash {
+pub trait RustInputPat: Eq + Hash + fmt::Debug {
     fn rust_pat_ty() -> Src;
     fn rust_slice_ty() -> Src;
     fn rust_matcher(&self) -> Src;
 }
 
-impl<S: Eq + Hash + AsRef<str>> RustInputPat for scannerless::Pat<S> {
+impl<S: Eq + Hash + fmt::Debug + AsRef<str>> RustInputPat for scannerless::Pat<S> {
     fn rust_pat_ty() -> Src {
         quote!(gll::grammer::scannerless::Pat<&'static str>)
     }
@@ -197,7 +197,7 @@ impl<Pat: RustInputPat> RuleMethods<Pat> for IRule {
     fn parse_node_desc(self, cx: &Context<Pat>, rules: &mut RuleMap<'_>) -> String {
         match cx[self] {
             Rule::Empty => "".to_string(),
-            Rule::Eat(ref pat) => pat.rust_matcher().to_pretty_string(),
+            Rule::Eat(ref pat) => format!("{:?}", pat),
             Rule::Call(r) => cx[r].to_string(),
             Rule::Concat([left, right]) => format!(
                 "({} {})",

--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -35,7 +35,11 @@ impl<S: Eq + Hash + fmt::Debug + AsRef<str>> RustInputPat for scannerless::Pat<S
 
 impl RustInputPat for proc_macro::Pat {
     fn rust_pat_ty() -> Src {
-        quote!(&'static [gll::grammer::proc_macro::FlatTokenPat<&'static str>])
+        quote!(
+            gll::grammer::proc_macro::Pat<
+                &'static [gll::grammer::proc_macro::FlatTokenPat<&'static str>],
+            >
+        )
     }
     fn rust_slice_ty() -> Src {
         quote!([gll::grammer::proc_macro::FlatToken])

--- a/src/parse_grammar.rs
+++ b/src/parse_grammar.rs
@@ -9,7 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/parse_grammar.rs"));
 
 use grammer::context::Context;
 use grammer::parser::ParseError;
-use grammer::proc_macro::{FlatToken, FlatTokenPat, Span, TokenStream};
+use grammer::proc_macro::{FlatToken, FlatTokenPat, Pat as PMPat, Span, TokenStream};
 use grammer::rule;
 use grammer::scannerless::Pat as SPat;
 use std::hash::Hash;
@@ -19,7 +19,7 @@ use std::str::FromStr;
 pub fn parse_grammar<Pat: Eq + Hash + From<SPat>>(
     cx: &mut Context<Pat>,
     stream: TokenStream,
-) -> Result<grammer::Grammar, ParseError<Span, &'static [FlatTokenPat<&'static str>]>> {
+) -> Result<grammer::Grammar, ParseError<Span, PMPat<&'static [FlatTokenPat<&'static str>]>>> {
     let mut grammar = grammer::Grammar::new();
     Grammar::parse(stream)?.with(|g| {
         for rule_def in g.one().unwrap().rules {

--- a/src/parse_grammar.rs
+++ b/src/parse_grammar.rs
@@ -9,7 +9,7 @@ include!(concat!(env!("OUT_DIR"), "/parse_grammar.rs"));
 
 use grammer::context::Context;
 use grammer::parser::ParseError;
-use grammer::proc_macro::{FlatToken, Span, TokenStream};
+use grammer::proc_macro::{FlatToken, FlatTokenPat, Span, TokenStream};
 use grammer::rule;
 use grammer::scannerless::Pat as SPat;
 use std::hash::Hash;
@@ -19,7 +19,7 @@ use std::str::FromStr;
 pub fn parse_grammar<Pat: Eq + Hash + From<SPat>>(
     cx: &mut Context<Pat>,
     stream: TokenStream,
-) -> Result<grammer::Grammar, ParseError<Span>> {
+) -> Result<grammer::Grammar, ParseError<Span, &'static [FlatTokenPat<&'static str>]>> {
     let mut grammar = grammer::Grammar::new();
     Grammar::parse(stream)?.with(|g| {
         for rule_def in g.one().unwrap().rules {


### PR DESCRIPTION
Now they should look identical to syntax that can be used to create them.
*Blocked on https://github.com/LykenSol/grammer/pull/7 and https://github.com/rust-lang/gll/pull/123.*