### PR TITLE
Update for grammer not requiring &mut Context for interning.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ doctest = false
 test = false
 
 [patch.'crates-io']
-grammer = { git = "https://github.com/lykenware/grammer", rev = "b0246724b67f50046d179e962c897eafe4cd0f26" }
+grammer = { git = "https://github.com/lykenware/grammer", rev = "ba41b3049ed294c5606309f82b2708261abddb30" }
 
 [workspace]
 members = [

--- a/build.rs
+++ b/build.rs
@@ -13,13 +13,13 @@ fn main() {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-    let mut cx = grammer::proc_macro::Context::new();
-    let mut grammar = grammer::proc_macro::builtin(&mut cx);
-    grammar.extend(grammer::grammar_grammar(&mut cx));
+    let cx = grammer::proc_macro::Context::new();
+    let mut grammar = grammer::proc_macro::builtin(&cx);
+    grammar.extend(grammer::grammar_grammar(&cx));
 
     fs::write(
         &out_dir.join("parse_grammar.rs"),
-        generate::rust::generate(&mut cx, &grammar).to_rustfmt_or_pretty_string(),
+        generate::rust::generate(&cx, &grammar).to_rustfmt_or_pretty_string(),
     )
     .unwrap();
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -7,19 +7,19 @@ use proc_quote::ToTokens as _;
 
 #[proc_macro]
 pub fn scannerless_parser(input: TokenStream) -> TokenStream {
-    let mut cx = gll::grammer::scannerless::Context::new();
-    let grammar = gll::parse_grammar(&mut cx, input.into()).unwrap();
-    gll::generate::rust::generate(&mut cx, &grammar)
+    let cx = gll::grammer::scannerless::Context::new();
+    let grammar = gll::parse_grammar(&cx, input.into()).unwrap();
+    gll::generate::rust::generate(&cx, &grammar)
         .into_token_stream()
         .into()
 }
 
 #[proc_macro]
 pub fn proc_macro_parser(input: TokenStream) -> TokenStream {
-    let mut cx = gll::grammer::proc_macro::Context::new();
-    let mut grammar = gll::grammer::proc_macro::builtin(&mut cx);
-    grammar.extend(gll::parse_grammar(&mut cx, input.into()).unwrap());
-    gll::generate::rust::generate(&mut cx, &grammar)
+    let cx = gll::grammer::proc_macro::Context::new();
+    let mut grammar = gll::grammer::proc_macro::builtin(&cx);
+    grammar.extend(gll::parse_grammar(&cx, input.into()).unwrap());
+    gll::generate::rust::generate(&cx, &grammar)
         .into_token_stream()
         .into()
 }

--- a/src/generate/templates/header.rs
+++ b/src/generate/templates/header.rs
@@ -18,7 +18,7 @@ impl<I: gll::grammer::input::Input, T: ?Sized> OwnedHandle<I, T> {
 }
 
 pub struct Handle<'a, 'i, I: gll::grammer::input::Input, T: ?Sized> {
-    pub node: ParseNode<'i, _P>,
+    pub node: Node<'i, _P>,
     pub forest: &'a gll::grammer::forest::ParseForest<'i, _G, I>,
     _marker: PhantomData<T>,
 }
@@ -127,8 +127,8 @@ impl<'a, 'i, I: gll::grammer::input::Input, T> Iterator for Handle<'a, 'i, I, [T
                 if iter.next().is_none() {
                     Some(Ok(elem))
                 } else {
-                    match self.forest.grammar.parse_node_shape(self.node.kind) {
-                        ParseNodeShape::Opt(_) => {
+                    match self.forest.grammar.node_shape(self.node.kind) {
+                        NodeShape::Opt(_) => {
                             self.node.range.0 = original.node.range.frontiers().0;
                         }
                         _ => unreachable!(),
@@ -172,7 +172,7 @@ impl<'a, 'i, I: gll::grammer::input::Input, T> Handle<'a, 'i, I, [T]> {
         // separated lists, an empty `Handle<[T]>` can be any optional node.
 
         // A maybe empty-list is always optional, peel that off first.
-        if let ParseNodeShape::Opt(_) = self.forest.grammar.parse_node_shape(self.node.kind) {
+        if let NodeShape::Opt(_) = self.forest.grammar.node_shape(self.node.kind) {
             if let Some(opt_child) = self.forest.unpack_opt(self.node) {
                 self.node = opt_child;
             } else {

--- a/src/generate/templates/imports.rs
+++ b/src/generate/templates/imports.rs
@@ -1,5 +1,4 @@
-use gll::grammer::forest::{nd::Arrow, traverse, GrammarReflector as _, ParseNode};
-use gll::grammer::parse_node::ParseNodeShape;
+use gll::grammer::forest::{nd::Arrow, traverse, GrammarReflector as _, Node, NodeShape};
 use std::any;
 use std::fmt;
 use std::marker::PhantomData;


### PR DESCRIPTION
See https://github.com/LykenSol/grammer/pull/9.