### PR TITLE
Update grammer for ParseError-related fixes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ doctest = false
 test = false
 
 [patch.'crates-io']
-grammer = { git = "https://github.com/lykenware/grammer", rev = "ba41b3049ed294c5606309f82b2708261abddb30" }
+grammer = { git = "https://github.com/lykenware/grammer", rev = "6f6f1320336d84b75805907fb302a28cb6d4cfb0" }
 
 [workspace]
 members = [

--- a/macros/tests/basic.rs
+++ b/macros/tests/basic.rs
@@ -96,7 +96,7 @@ testcases![
     },
 }",
 // FIXME(eddyb) get replace quotes with backticks and pretify the `expected` list.
-    S("aax") => r#"1:3: error: expected ["d", "d", "a", "b", "a", "c"]"#;
+    S("aax") => r#"1:3: error: expected ["a", "b", "c", "d"]"#;
 
     gll10_g0_opaque {
         S = { a:A s:S "d" } |

--- a/macros/tests/json.rs
+++ b/macros/tests/json.rs
@@ -140,7 +140,7 @@ fn json_like_error() {
         stray_identifier
     };
 
-    let expected = r#"?: error: expected ["null", "false", "true", "[", "{", "(", LITERAL]"#;
+    let expected = r#"?: error: expected ["(", "[", "{", "false", "null", "true", LITERAL]"#;
 
     json_like_testcase(input, expected);
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -20,7 +20,7 @@ struct RuntimeState<'i, C: CodeLabel> {
     memoizer: Memoizer<'i, C>,
 }
 
-impl<'i, P, G, C, I: Input, Pat> Runtime<'_, 'i, C, I, Pat>
+impl<'i, P, G, C, I: Input, Pat: Ord> Runtime<'_, 'i, C, I, Pat>
 where
     // FIXME(eddyb) these shouldn't be needed, as they are bounds on
     // `GrammarReflector::NodeKind`, but that's ignored currently.


### PR DESCRIPTION
See https://github.com/LykenSol/grammer/pull/12.