### PR TITLE
Update grammer for Node<'i, P> -> Node<'i, G>.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ doctest = false
 test = false
 
 [patch.'crates-io']
-grammer = { git = "https://github.com/lykenware/grammer", rev = "c36836d09c2f8954b7535d38e9ca57c8a6f5041e" }
+grammer = { git = "https://github.com/lykenware/grammer", rev = "3c8cef4f42ac8cb2483fc14e55dfdd180d74a96a" }
 
 [workspace]
 members = [

--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -1084,8 +1084,8 @@ where
             #[allow(non_snake_case)]
             fn #variants_from_forest_ident(
                 forest: &'a gll::grammer::forest::ParseForest<'i, _G, I>,
-                _node: Node<'i, _P>,
-                _r: traverse!(typeof(Node<'i, _P>) #variants_shape),
+                _node: Node<'i, _G>,
+                _r: traverse!(typeof(Node<'i, _G>) #variants_shape),
             ) -> Self {
                 #variants_body
             }
@@ -1103,8 +1103,8 @@ where
             quote!(
                 fn from_forest(
                     forest: &'a gll::grammer::forest::ParseForest<'i, _G, I>,
-                    _node: Node<'i, _P>,
-                    _r: traverse!(typeof(Node<'i, _P>) #shape),
+                    _node: Node<'i, _G>,
+                    _r: traverse!(typeof(Node<'i, _G>) #shape),
                 ) -> Self {
                     #ident {
                         #(#fields_ident: #fields_expr),*
@@ -1538,7 +1538,6 @@ fn code_label_decl_and_impls<Pat>(
         }
         impl gll::runtime::CodeLabel for _C {
             type GrammarReflector = _G;
-            type NodeKind = _P;
 
             fn enclosing_fn(self) -> Self {
                 match self {

--- a/src/generate/templates/header.rs
+++ b/src/generate/templates/header.rs
@@ -4,7 +4,7 @@ pub type Any = dyn any::Any;
 pub struct Ambiguity<T>(T);
 
 pub struct OwnedHandle<I: gll::grammer::input::Input, T: ?Sized> {
-    forest_and_node: gll::grammer::forest::OwnedParseForestAndNode<_G, _P, I>,
+    forest_and_node: gll::grammer::forest::OwnedParseForestAndNode<_G, I>,
     _marker: PhantomData<T>,
 }
 
@@ -18,7 +18,7 @@ impl<I: gll::grammer::input::Input, T: ?Sized> OwnedHandle<I, T> {
 }
 
 pub struct Handle<'a, 'i, I: gll::grammer::input::Input, T: ?Sized> {
-    pub node: Node<'i, _P>,
+    pub node: Node<'i, _G>,
     pub forest: &'a gll::grammer::forest::ParseForest<'i, _G, I>,
     _marker: PhantomData<T>,
 }


### PR DESCRIPTION
See https://github.com/LykenSol/grammer/pull/14.