### PR TITLE
Fixes for new errors from lints (rust_2018_idioms, ambiguous_associated_items).

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(rust_2018_idioms)]
 
-extern crate proc_macro;
-
 use proc_macro::TokenStream;
 use proc_quote::ToTokens as _;
 

--- a/src/generate/rust.rs
+++ b/src/generate/rust.rs
@@ -528,7 +528,7 @@ impl<Pat: MatchesEmpty + RustInputPat> GrammarGenerateMethods<Pat> for grammer::
 
                     fn from_shape_fields(
                         forest: &'a _forest::ParseForest<'i, _G, I>,
-                        [#(#f_ident),*]: Self::Fields,
+                        [#(#f_ident),*]: <Self as _forest::typed::FromShapeFields<'a, 'i, _G, I>>::Fields,
                     ) -> Self::Output {
                         #ident {
                             #(#f_ident: #f_ident::from_shape_fields(forest, [#f_ident])),*
@@ -1255,7 +1255,7 @@ where
 
         fn from_shape_fields(
             forest: &'a _forest::ParseForest<'i, _G, I>,
-            fields: Self::Fields,
+            fields: <Self as _forest::typed::FromShapeFields<'a, 'i, _G, I>>::Fields,
         ) -> Self {
             #from_shape
         }


### PR DESCRIPTION
This is needed to use latest `gll` (which is more forgiving field-wise) with `wg-grammar`.